### PR TITLE
Changed Intern to be passed a string (standard) instead of uninterned symbol - it was crashing SBCL/Linux64 compiler.

### DIFF
--- a/source/suite.lisp
+++ b/source/suite.lisp
@@ -96,7 +96,7 @@ Package NAME is defined via normal `defpackage', and in addition to processing
 PACKAGE-OPTIONS, automatically USEs the :STEFIL and :CL packages."
   (unless (find-package name)
     (make-package name :use nil))
-  (let ((run-package-tests (intern '#:run-package-tests name))
+  (let ((run-package-tests (intern "RUN-PACKAGE-TESTS" name))
         (suite-sym (intern (string name) :stefil-suites)))
     `(progn
        (defpackage ,name


### PR DESCRIPTION
...crashing tip SBCL/Linux64 compiler - changed to accept a string literal
