### PR TITLE
Don't create a RUN-PACKAGE-TESTS in every package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 Stefil
 ======
 
-Stefil is a great and simple test framework in lisp.
+Stefil is a simple and powerful test framework for Common Lisp.
 
-Read about [here][old-intro] or scroll down for a simple example demonstrating
-just few features.
+There's a fairly outdated introduction [here][old-intro], but scroll
+down for a simple example demonstrating just few features.
 
 Up and running
 --------------
@@ -23,11 +23,11 @@ or alternatively, just use [asdf][asdf]
 (asdf:require-system :stefil)
 ```
 
-now create some lisp file with
+now create some Lisp file with
 
 ```lisp
-(stefil:define-test-package :stefil-examples)
-(in-package :stefil-examples)
+(defpackage #:example-time (:export #:seconds #:hours-and-minutes))
+(in-package #:example-time)
 
 (defun seconds (hours-and-minutes)
   (+ (* 3600 (first hours-and-minutes))
@@ -36,6 +36,10 @@ now create some lisp file with
 (defun hours-and-minutes (seconds)
   (list (truncate seconds 3600)
         (truncate seconds 60)))
+
+(stefil:define-test-package #:stefil-examples
+  (:use #:example-time))
+(in-package #:stefil-examples)
 
 (deftest test-conversion-to-hours-and-minutes ()
   (is (equal (hours-and-minutes 180) '(0 3)))
@@ -51,7 +55,8 @@ now create some lisp file with
 ```
 load or compile it, and in your REPL run
 
-    > (stefil-examples:run-package-tests)
+    > (in-package :stefil-examples)
+    STEFIL-EXAMPLES> (run-package-tests)
     STEFIL-EXAMPLES (Suite)
       TEST-CONVERSION-TO-SECONDS                                                    [FAIL]
       TEST-CONVERSION-TO-HOURS-AND-MINUTES                                          [FAIL]
@@ -79,7 +84,7 @@ Yay, everything fails!
 Debugging failures
 ------------------
 
-Run the example again, with `:interactive t` to bring up the lisp debugger 
+Run the example again, with `:interactive t` to bring up the Lisp debugger 
 every time a test failure happens. They are caused by error conditions or 
 test assertion failures. We have two of the former and one of the latter.
 
@@ -95,7 +100,8 @@ be rewritten like:
 
 After that, you'll see a nice
 
-    > (stefil-examples:run-package-tests)
+    > (in-package :stefil-examples)
+    STEFIL-EXAMPLES> (run-package-tests)
     STEFIL-EXAMPLES (Suite)
       TEST-CONVERSION-TO-SECONDS                                                    [ OK ]
       TEST-CONVERSION-TO-HOURS-AND-MINUTES                                          [ OK ]

--- a/source/package.lisp
+++ b/source/package.lisp
@@ -51,5 +51,6 @@
            #:*warn-about-test-redefinitions*
            #:all-tests
            #:define-test-package
+           #:run-package-tests
            #:describe-failed-tests
            #:run-suite-tests))

--- a/test/basic.lisp
+++ b/test/basic.lisp
@@ -4,7 +4,7 @@
 ;;;
 ;;; See LICENCE for details.
 
-(in-package :stefil-test)
+(in-package :stefil-self-tests)
 
 (defsuite* (test :in root-suite :documentation "Stefil self tests"))
 

--- a/test/fixtures.lisp
+++ b/test/fixtures.lisp
@@ -4,7 +4,7 @@
 ;;;
 ;;; See LICENCE for details.
 
-(in-package :stefil-test)
+(in-package :stefil-self-tests)
 
 (defsuite* (fixtures :in test))
 

--- a/test/intro-example.lisp
+++ b/test/intro-example.lisp
@@ -1,0 +1,56 @@
+(defpackage #:example-time (:export #:seconds #:hours-and-minutes))
+(in-package #:example-time)
+
+(defun seconds (hours-and-minutes)
+  (+ (* 3600 (first hours-and-minutes))
+     (* 60 (seconds hours-and-minutes))))
+
+(defun hours-and-minutes (seconds)
+  (list (truncate seconds 3600)
+        (truncate seconds 60)))
+
+(stefil:define-test-package #:stefil-examples
+  (:use #:example-time))
+(in-package #:stefil-examples)
+
+(deftest test-conversion-to-hours-and-minutes ()
+  (is (equal (hours-and-minutes 180) '(0 3)))
+  (is (equal (hours-and-minutes 4500) '(1 15))))
+
+(deftest test-conversion-to-seconds ()
+  (is (= 60 (seconds '(0 1))))
+  (is (= 4500 (seconds '(1 15)))))
+
+(deftest double-conversion ()
+  (is (= 3600 (seconds (hours-and-minutes 3600))))
+  (is (= 1234 (seconds (hours-and-minutes 1234)))))
+
+(in-package :stefil-self-tests)
+
+;; define a metatest to test the other test
+;;
+(deftest intro-metatest ()
+  (let ((*debug-on-unexpected-error* nil)
+        (*debug-on-assertion-failure* nil))
+    (let ((run (with-new-global-context* ()
+                 (run-package-tests :package :stefil-examples)
+                 ;; must access *GLOBAL-CONTEXT* directly, otherwise
+                 ;; we get the run of running INTRO-METATEST itself
+                 *global-context*)))
+      (destructuring-bind (&key number-of-tests-run
+                                number-of-assertions
+                                number-of-failures
+                                number-of-failed-assertions
+                                number-of-unexpected-errors
+                                number-of-expected-failures
+                            &allow-other-keys)
+          (extract-test-run-statistics run)
+        ;; Remember that the suite itself counts as a test and so it's
+        ;; an assertion. FIXME: this is confusing as hell
+        (is (= 4 number-of-assertions))
+        (is (= 4 number-of-tests-run))
+        (is (= 3 number-of-failures))
+        (is (= 1 number-of-failed-assertions))
+        (is (= 2 number-of-unexpected-errors))
+        (is (= 0 number-of-expected-failures))))))
+  

--- a/test/package.lisp
+++ b/test/package.lisp
@@ -6,7 +6,7 @@
 
 (in-package :common-lisp-user)
 
-(defpackage :stefil-test
+(defpackage :stefil-self-tests
   (:use :alexandria
         :common-lisp
         :stefil)
@@ -18,4 +18,4 @@
 
 (in-package :stefil)
 
-(import-all-owned-symbols :stefil :stefil-test)
+(import-all-owned-symbols :stefil :stefil-self-tests)

--- a/test/stefil-test.asd
+++ b/test/stefil-test.asd
@@ -4,10 +4,11 @@
 ;;;
 ;;; See LICENCE for details.
 
-(defsystem :stefil-test
-  :licence "BSD / Public domain"
+(asdf:defsystem :stefil-self-tests
+    :licence "BSD / Public domain"
   :depends-on (:stefil)
   :serial t
   :components ((:file "package")
                (:file "basic")
-               (:file "fixtures")))
+               (:file "fixtures")
+               (:file "intro-example")))


### PR DESCRIPTION
- README.md: Adjust README.md to new RUN-PACKAGE-TESTS and tweak
  it.
- test/package.lisp (defpackage :stefil-self-tests): Renamed from
  :STEFIL-TESTS for clarity.
- source/suite.lisp (define-test-package): Don't define
  RUN-PACKAGE-TESTS function in target package.
  (run-package-tests): New exported function. Takes a PACKAGE kwarg that
  defaults to _PACKAGE_
  (run-suite-tests): Take a SUITE-DESIGNATOR instead of a SUITE-SYM.
- test/basic.lisp (depackage :stefil-self-tests): Renamed from
  :STEFIL-TESTS for clarity.
- test/intro-example.lisp: New file.
- test/stefil-test.asd (asdf:defsystem :stefil-self-tests): Add
  "intro-example.lisp"
